### PR TITLE
Modif ID salon des logs

### DIFF
--- a/config-example.json
+++ b/config-example.json
@@ -3,5 +3,5 @@
   "prefix": ".",
   "activity": "les nouveaux membres",
 
-  "join_logs_chan": 00000000000000000
+  "join_logs_chan": 12345678912345678
 }


### PR DESCRIPTION
0 est considéré comme une valeur nulle et cause une erreur de validation du fichier json (https://jsonlint.com/)